### PR TITLE
fix DB_URL error

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const DB_URL = 'mongodb://localhost:27017/ballers' || process.env.DB_URL;
+const DB_URL = process.env.DB_URL || 'mongodb://localhost:27017/ballers';
 const PORT = process.env.PORT || 3000;
 
 export { DB_URL, PORT };


### PR DESCRIPTION
**What does this PR do?**
Fixes the error that occurs when you run `npm run start` and the `mongod` service isn't running


**Description of task completed**
Fixed error of changing `const DB_URL = 'mongodb://localhost:27017/ballers' || process.env.DB_URL;` back to `const DB_URL = process.env.DB_URL || 'mongodb://localhost:27017/ballers';` 