### PR TITLE
#172304631 Enable Users to reset password via Forgot Password

### DIFF
--- a/mailer/index.js
+++ b/mailer/index.js
@@ -5,6 +5,13 @@ const EMAIL_CONTENT = {
       'Your Ballers.ng account has been successfully created. To complete your registration, you need to confirm that we got your email address right.',
     subject: 'Verify your Email',
   },
+  CHANGE_PASSWORD: {
+    buttonText: 'Reset Password',
+    contentBottom:
+      "If you didn't change your password, your account might have been compromised and we recommend that you reset your password as soon as possible.",
+    contentTop: 'This email confirms that your password has been changed.',
+    subject: 'Your password has been changed!',
+  },
   DEFAULT: {
     buttonText: 'Button Text',
     contentBottom: 'Bottom content is here',
@@ -13,6 +20,13 @@ const EMAIL_CONTENT = {
     greeting: 'Welcome',
     link: 'sample link',
     subject: 'Email Subject is Here',
+  },
+  RESET_PASSWORD_LINK: {
+    buttonText: 'Reset Password',
+    contentBottom: "If you didn't request a password reset, let us know as soon as possible",
+    contentTop:
+      "You (or someone pretending to be you) requested a password reset for your account. If you didn't made this request you can ignore this email.",
+    subject: 'Password Reset',
   },
 };
 

--- a/server/routes/user.routes.js
+++ b/server/routes/user.routes.js
@@ -1,5 +1,10 @@
 import express from 'express';
-import { registerSchema, loginSchema } from '../schemas/user.schema';
+import {
+  registerSchema,
+  loginSchema,
+  resetPasswordSchema,
+  changePasswordSchema,
+} from '../schemas/user.schema';
 import { schemaValidation } from '../helpers/middleware';
 import UserController from '../controllers/user.controllers';
 
@@ -87,5 +92,79 @@ router.post('/login', schemaValidation(loginSchema), UserController.login);
  *          description: Internal server error
  */
 router.get('/activate', UserController.activateToken);
+
+/**
+ * @swagger
+ * /user/reset-password:
+ *   post:
+ *     tags:
+ *       - User
+ *     description: Sends a reset password link to user
+ *     produces:
+ *       - application/json
+ *     requestBody:
+ *      content:
+ *        application/json:
+ *          schema:
+ *            type: object
+ *            properties:
+ *              email:
+ *                  type: string
+ *                  example: john@mail.com
+ *      description: Generates Reset Password Link
+ *     responses:
+ *      '200':
+ *        description: A password reset link has been sent to your email account
+ *      '401':
+ *        description: Your email address is not found. Please check and Try Again.
+ *      '500':
+ *       description: Internal server error
+ */
+router.post(
+  '/reset-password',
+  schemaValidation(resetPasswordSchema),
+  UserController.generateResetPasswordLink,
+);
+
+/**
+ * @swagger
+ * /user/change-password:
+ *   post:
+ *     tags:
+ *       - User
+ *     description: Changes a User Password
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - in: path
+ *         name: token
+ *         required: true
+ *         schema:
+ *          type: string
+ *         description: the auto generated user token via jwt
+ *       - in: formData
+ *         name: password
+ *         schema:
+ *          type: string
+ *         description: the new password
+ *       - in: formData
+ *         name: confirmPassword
+ *         schema:
+ *          type: string
+ *         description: confirm password
+ *     summary: Changes a user password
+ *     responses:
+ *      '200':
+ *        description: Your password has been successfully changed
+ *      '404':
+ *        description: User not found
+ *      '500':
+ *       description: Internal server error
+ */
+router.post(
+  '/change-password/:token',
+  schemaValidation(changePasswordSchema),
+  UserController.resetPasswordFromLink,
+);
 
 module.exports = router;

--- a/server/schemas/user.schema.js
+++ b/server/schemas/user.schema.js
@@ -1,17 +1,32 @@
 import Joi from '@hapi/joi';
 
+const email = Joi.string().label('Email Address').email().required();
+const password = Joi.string().label('Password').min(6).required().strict();
+const confirmPassword = Joi.string().valid(Joi.ref('password')).required().strict().messages({
+  'any.only': 'Password does not match',
+});
+const phone = Joi.string().allow(null, '').optional().default('');
+const requiredString = (label) => Joi.string().label(label).required();
+
 export const registerSchema = Joi.object({
-  firstName: Joi.string().label('First Name').required(),
-  lastName: Joi.string().label('Last Name').required(),
-  email: Joi.string().label('Email Address').email().required(),
-  password: Joi.string().label('Password').min(6).required().strict(),
-  confirmPassword: Joi.string().valid(Joi.ref('password')).required().strict().messages({
-    'any.only': 'Password does not match',
-  }),
-  phone: Joi.string().allow(null, '').optional().default(''),
+  firstName: requiredString('First Name'),
+  lastName: requiredString('Last Name'),
+  email,
+  phone,
+  password,
+  confirmPassword,
 });
 
 export const loginSchema = Joi.object({
-  email: Joi.string().label('Email Address').email().required(),
-  password: Joi.string().label('Password').min(6).required().strict(),
+  email,
+  password,
+});
+
+export const resetPasswordSchema = Joi.object({
+  email,
+});
+
+export const changePasswordSchema = Joi.object({
+  password,
+  confirmPassword,
 });

--- a/server/services/user.service.js
+++ b/server/services/user.service.js
@@ -97,14 +97,13 @@ export const forgotPasswordToken = async (email) => {
     const savedUser = existingUser.toJSON();
     return { user: savedUser, token: generateToken(savedUser._id, '1h') };
   }
-  throw new ErrorHandler(401, 'Your email address is not found. Please check and Try Again.');
+  throw new ErrorHandler(404, 'Your email address is not found.');
 };
 
 export const resetPasswordViaToken = async (password, token) => {
   try {
     const decoded = await decodeToken(token);
     const hashedPassword = await hashPassword(password);
-    console.log('decoded', decoded);
     return User.findOneAndUpdate(
       { _id: decoded.id },
       { $set: { password: hashedPassword } },

--- a/test/controllers/user.controller.test.js
+++ b/test/controllers/user.controller.test.js
@@ -8,17 +8,17 @@ import EMAIL_CONTENT from '../../mailer';
 
 useDatabase();
 
+let sendMailSpy;
+const sandbox = sinon.createSandbox();
+beforeEach(() => {
+  sendMailSpy = sandbox.spy(MailService, 'sendMail');
+});
+
+afterEach(() => {
+  sandbox.restore();
+});
+
 describe('Register Route', () => {
-  let sendMailSpy;
-  const sandbox = sinon.createSandbox();
-  beforeEach(() => {
-    sendMailSpy = sandbox.spy(MailService, 'sendMail');
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   context('with valid data', () => {
     it('returns successful token', (done) => {
       const user = UserFactory.build({ email: 'myemail@mail.com' });
@@ -377,6 +377,155 @@ describe('Activate User Route', () => {
         .end((err, res) => {
           expect(res).to.have.status(404);
           expect(res.body.success).to.be.eql(false);
+          done();
+        });
+    });
+  });
+});
+
+describe('Generate a Password Reset Link', () => {
+  const email = 'myemail@mail.com';
+  const user = UserFactory.build({ email });
+
+  beforeEach(async () => {
+    await addUser(user);
+  });
+
+  context('with a valid token', () => {
+    it('returns successful payload', (done) => {
+      request()
+        .post('/api/v1/user/reset-password')
+        .send({ email })
+        .end((err, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body.success).to.be.eql(true);
+          expect(res.body.message).to.be.eql(
+            'A password reset link has been sent to your email account',
+          );
+          expect(sendMailSpy.callCount).to.eq(1);
+          expect(sendMailSpy).to.have.be.calledWith(EMAIL_CONTENT.RESET_PASSWORD_LINK);
+          done();
+        });
+    });
+  });
+
+  context('with an invalid email', () => {
+    it('returns successful payload', (done) => {
+      request()
+        .post('/api/v1/user/reset-password')
+        .send({ email: 'invalid@email.com' })
+        .end((err, res) => {
+          expect(res).to.have.status(404);
+          expect(res.body.success).to.be.eql(false);
+          expect(res.body.message).to.be.eql('Your email address is not found.');
+          expect(res.body.error).to.be.eql('Your email address is not found.');
+          expect(sendMailSpy.callCount).to.eq(0);
+          done();
+        });
+    });
+  });
+});
+
+describe('Change Password from Reset Link', () => {
+  let token;
+  const password = '123@ABC';
+  const confirmPassword = '123@ABC';
+  const user = UserFactory.build();
+
+  beforeEach(async () => {
+    token = await addUser(user);
+  });
+
+  context('with a valid token', () => {
+    it('returns successful payload', (done) => {
+      request()
+        .post(`/api/v1/user/change-password/${token}`)
+        .send({ password, confirmPassword })
+        .end((err, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body.success).to.be.eql(true);
+          expect(res.body.message).to.be.eql('Your password has been successfully changed');
+          expect(sendMailSpy.callCount).to.eq(1);
+          expect(sendMailSpy).to.have.be.calledWith(EMAIL_CONTENT.CHANGE_PASSWORD);
+          done();
+        });
+    });
+  });
+
+  context('when password is empty', () => {
+    it('returns an error', (done) => {
+      request()
+        .post(`/api/v1/user/change-password/${token}`)
+        .send({ password: '', confirmPassword })
+        .end((err, res) => {
+          expect(res).to.have.status(412);
+          expect(res.body.success).to.be.eql(false);
+          expect(res.body.message).to.be.eql('Validation Error');
+          expect(res.body.error).to.be.eql('"Password" is not allowed to be empty');
+          expect(sendMailSpy.callCount).to.eq(0);
+          done();
+        });
+    });
+  });
+
+  context('when password is weak', () => {
+    it('returns an error', (done) => {
+      request()
+        .post(`/api/v1/user/change-password/${token}`)
+        .send({ password: '123', confirmPassword })
+        .end((err, res) => {
+          expect(res).to.have.status(412);
+          expect(res.body.success).to.be.eql(false);
+          expect(res.body.message).to.be.eql('Validation Error');
+          expect(res.body.error).to.be.eql('"Password" length must be at least 6 characters long');
+          expect(sendMailSpy.callCount).to.eq(0);
+          done();
+        });
+    });
+  });
+
+  context('when confirm password is empty', () => {
+    it('returns an error', (done) => {
+      request()
+        .post(`/api/v1/user/change-password/${token}`)
+        .send({ password, confirmPassword: '' })
+        .end((err, res) => {
+          expect(res).to.have.status(412);
+          expect(res.body.success).to.be.eql(false);
+          expect(res.body.message).to.be.eql('Validation Error');
+          expect(res.body.error).to.be.eql('Password does not match');
+          expect(sendMailSpy.callCount).to.eq(0);
+          done();
+        });
+    });
+  });
+
+  context('when confirm password is not equal to password', () => {
+    it('returns an error', (done) => {
+      request()
+        .post(`/api/v1/user/change-password/${token}`)
+        .send({ password, confirmPassword: '000000' })
+        .end((err, res) => {
+          expect(res).to.have.status(412);
+          expect(res.body.success).to.be.eql(false);
+          expect(res.body.message).to.be.eql('Validation Error');
+          expect(res.body.error).to.be.eql('Password does not match');
+          expect(sendMailSpy.callCount).to.eq(0);
+          done();
+        });
+    });
+  });
+
+  context('with invalid token', () => {
+    it('returns an error', (done) => {
+      request()
+        .post(`/api/v1/user/change-password/123456`)
+        .send({ password, confirmPassword })
+        .end((err, res) => {
+          expect(res).to.have.status(404);
+          expect(res.body.success).to.be.eql(false);
+          expect(res.body.message).to.be.eql('User not found');
+          expect(sendMailSpy.callCount).to.eq(0);
           done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
This PR enables a user to do a password reset via a forgot password link. An email is sent to the user's email address from the forgot password endpoint. The link in the email can be used to access the change password which enables the user to reset their password.

#### Description of Task to be completed?
1. Create a reset password link which will be sent to the user via mail
2. Enable a user with a valid token to change their password
3. Send a mail to the user to inform the user that the password has been changed.

#### How should this be manually tested?
1. Check out into this branch
2. Run `npm install` to update dependencies
3. Start the API server on your local machine `npm run start:dev`
4. Visit `http://localhost:3000/api/v1/user/reset-password` and enter an existing email address
5. A password link is sent to MailTrap.
6. Copy the token in the link and visit `http://localhost:3000/api/v1/user/change-password/{token}`. Replace {token} with the copied token from MailTrap
6. Enter your proposed password and confirmPassword via JSON.
7. You should receive a message confirming a successful password change
8. Another mail should be sent to MailTrap to confirm the password change.

#### Screenshot
<kbd>
<img width="1082" alt="Screenshot 2020-04-24 at 6 51 00 PM" src="https://user-images.githubusercontent.com/26963369/80242090-a9141400-865c-11ea-820f-387a33c24895.png">
</kbd>

<br>
<br>
<br>

<kbd>
<img width="1081" alt="Screenshot 2020-04-24 at 6 51 12 PM" src="https://user-images.githubusercontent.com/26963369/80242112-b5986c80-865c-11ea-8533-265a0425fc72.png">
</kbd>

