### PR TITLE
#175868402 #175868469 make area search by name & fix case sensitivity

### DIFF
--- a/server/controllers/contentProperty.controllers.js
+++ b/server/controllers/contentProperty.controllers.js
@@ -51,8 +51,9 @@ const ContentPropertyController = {
   },
 
   search(req, res, next) {
-    const { areaId, houseType } = req.query;
-    getPropertiesByParameters({ areaId, houseType })
+    const { area, state } = req.query;
+    const houseType = req.query.type;
+    getPropertiesByParameters({ area, state, houseType })
       .then((evaluation) => {
         res.status(httpStatus.OK).json({ success: true, evaluation });
       })

--- a/server/controllers/contentProperty.controllers.js
+++ b/server/controllers/contentProperty.controllers.js
@@ -51,8 +51,7 @@ const ContentPropertyController = {
   },
 
   search(req, res, next) {
-    const { area, state } = req.query;
-    const houseType = req.query.type;
+    const { area, state, houseType } = req.query;
     getPropertiesByParameters({ area, state, houseType })
       .then((evaluation) => {
         res.status(httpStatus.OK).json({ success: true, evaluation });

--- a/server/models/area.model.js
+++ b/server/models/area.model.js
@@ -45,6 +45,7 @@ const AreaSchema = new mongoose.Schema(
     },
   },
   { timestamps: true },
+  { collation: { locale: 'en', strength: 2 } },
 );
 
 const Area = mongoose.model('Area', AreaSchema);

--- a/server/models/contentProperty.model.js
+++ b/server/models/contentProperty.model.js
@@ -62,6 +62,7 @@ const ContentPropertySchema = new mongoose.Schema(
     },
   },
   { timestamps: true },
+  { collation: { locale: 'en', strength: 2 } },
 );
 
 const ContentProperty = mongoose.model('ContentProperty', ContentPropertySchema);

--- a/server/routes/contentProperty.routes.js
+++ b/server/routes/contentProperty.routes.js
@@ -129,7 +129,7 @@ router.get('/area/:id', hasValidObjectId, ContentPropertyController.getHouseType
 
 /**
  * @swagger
- * /content-property/:
+ * /content-property/search:
  *   get:
  *     tags:
  *       - ContentProperty
@@ -148,7 +148,7 @@ router.get('/area/:id', hasValidObjectId, ContentPropertyController.getHouseType
  *      '500':
  *       description: Internal server error
  */
-router.get('/', ContentPropertyController.search);
+router.get('/search', ContentPropertyController.search);
 
 /**
  * @swagger

--- a/server/services/area.service.js
+++ b/server/services/area.service.js
@@ -9,11 +9,11 @@ const { ObjectId } = mongoose.Types.ObjectId;
 
 export const getAreaById = async (id) => Area.findById(id).select();
 
-export const getAreaByAreaName = async (areaName, stateName) =>
-  Area.find({ area: areaName.toLowerCase(), state: stateName.toLowerCase() }).select();
+export const getAreaByAreaAndStateName = async (areaName, stateName) =>
+  Area.find({ area: areaName, state: stateName }).collation({ locale: 'en', strength: 2 });
 
 export const addArea = async (area) => {
-  const areaExists = await getAreaByAreaName(area.area, area.state);
+  const areaExists = await getAreaByAreaAndStateName(area.area, area.state);
 
   if (areaExists.length > 0) {
     throw new ErrorHandler(httpStatus.PRECONDITION_FAILED, 'Area already exists');
@@ -21,8 +21,8 @@ export const addArea = async (area) => {
   try {
     const addedArea = await new Area({
       ...area,
-      area: area.area.toLowerCase(),
-      state: area.state.toLowerCase(),
+      area: area.area,
+      state: area.state,
     }).save();
     return addedArea;
   } catch (error) {
@@ -36,7 +36,7 @@ export const getStates = async () => {
 };
 
 export const getAreas = async (state) => {
-  const areas = await Area.find({ state }).select('area');
+  const areas = await Area.find({ state }).collation({ locale: 'en', strength: 2 });
   return { areas };
 };
 
@@ -50,8 +50,8 @@ export const updateArea = async (updatedArea) => {
 
   const areaPayload = {
     ...updatedArea,
-    area: updatedArea.area ? updatedArea.area.toLowerCase() : area.area,
-    state: updatedArea.state ? updatedArea.state.toLowerCase() : area.state,
+    area: updatedArea.area ? updatedArea.area : area.area,
+    state: updatedArea.state ? updatedArea.state : area.state,
   };
 
   try {

--- a/server/services/contentProperty.service.js
+++ b/server/services/contentProperty.service.js
@@ -97,11 +97,7 @@ export const getPropertiesByParameters = async ({ area, state, houseType }) => {
   const prices = await ContentProperty.aggregate([
     {
       $match: {
-        $and: [
-          { houseType: houseType || /.*/ },
-          // { houseType: houseType ? new RegExp(['^', houseType, '$'], 'i') : /.*/ },
-          { areaId: ObjectId(areaId) || /.*/ },
-        ],
+        $and: [{ houseType: houseType || /.*/ }, { areaId: ObjectId(areaId) || /.*/ }],
       },
     },
     {

--- a/server/services/contentProperty.service.js
+++ b/server/services/contentProperty.service.js
@@ -3,7 +3,7 @@ import ContentProperty from '../models/contentProperty.model';
 import { ErrorHandler } from '../helpers/errorHandler';
 import httpStatus from '../helpers/httpStatus';
 // eslint-disable-next-line import/no-cycle
-import { getAreaById } from './area.service';
+import { getAreaById, getAreaByAreaAndStateName } from './area.service';
 import { generatePagination, generateFacetData } from '../helpers/pagination';
 
 const { ObjectId } = mongoose.Types.ObjectId;
@@ -79,19 +79,29 @@ export const getHouseTypesByAreaId = async (areaId) => {
   return ContentProperty.find({ areaId }).distinct('houseType');
 };
 
-export const getPropertiesByParameters = async ({ areaId, houseType }) => {
-  const area = await getAreaById(areaId).catch((error) => {
+export const getPropertiesByParameters = async ({ area, state, houseType }) => {
+  if (!state || !area) {
+    throw new ErrorHandler(httpStatus.PRECONDITION_FAILED, 'Invalid state or area');
+  }
+
+  const areaExists = await getAreaByAreaAndStateName(area, state).catch((error) => {
     throw new ErrorHandler(httpStatus.INTERNAL_SERVER_ERROR, 'Internal Server Error', error);
   });
 
-  if (!area) {
+  if (areaExists.length < 1) {
     throw new ErrorHandler(httpStatus.NOT_FOUND, 'Area not found');
   }
+
+  const areaId = areaExists[0]._id;
 
   const prices = await ContentProperty.aggregate([
     {
       $match: {
-        $and: [{ houseType: houseType || /.*/ }, { areaId: ObjectId(areaId) || /.*/ }],
+        $and: [
+          { houseType: houseType || /.*/ },
+          // { houseType: houseType ? new RegExp(['^', houseType, '$'], 'i') : /.*/ },
+          { areaId: ObjectId(areaId) || /.*/ },
+        ],
       },
     },
     {
@@ -107,10 +117,10 @@ export const getPropertiesByParameters = async ({ areaId, houseType }) => {
   return {
     ...prices[0],
     type: houseType,
-    areaName: area.area,
-    stateName: area.state,
-    longitude: area.longitude,
-    latitude: area.latitude,
+    areaName: areaExists[0].area,
+    stateName: areaExists[0].state,
+    longitude: areaExists[0].longitude,
+    latitude: areaExists[0].latitude,
   };
 };
 

--- a/test/controllers/area.controller.test.js
+++ b/test/controllers/area.controller.test.js
@@ -287,8 +287,8 @@ describe('Area Controller', () => {
               expect(res).to.have.status(200);
               expect(res.body.success).to.be.eql(true);
               expect(res.body.area._id).to.be.eql(areaId.toString());
-              expect(res.body.area.area).to.be.eql(updatedArea.area.toLowerCase());
-              expect(res.body.area.state).to.be.eql(updatedArea.state.toLowerCase());
+              expect(res.body.area.area).to.be.eql(updatedArea.area);
+              expect(res.body.area.state).to.be.eql(updatedArea.state);
               expect(res.body.area.longitude).to.be.eql(updatedArea.longitude);
               expect(res.body.area.latitude).to.be.eql(updatedArea.latitude);
               done();
@@ -591,13 +591,13 @@ describe('Area Controller', () => {
               expect(res).to.have.status(200);
               expect(res.body.success).to.be.eql(true);
               expect(res.body.areas.length).to.be.eql(2);
-              expect(res.body.areas[0].area).to.be.eql(ajah.area.toLowerCase());
+              expect(res.body.areas[0].area).to.be.eql(ajah.area);
               expect(res.body.areas[0].numOfProperties).to.be.eql(0);
               expect(res.body.areas[0].minimumPrice).to.be.eql(null);
               expect(res.body.areas[0].maximumPrice).to.be.eql(null);
               expect(res.body.areas[0].averagePrice).to.be.eql(null);
               expect(res.body.areas[1]._id).to.be.eql(lekkiId.toString());
-              expect(res.body.areas[1].area).to.be.eql(lekki.area.toLowerCase());
+              expect(res.body.areas[1].area).to.be.eql(lekki.area);
               expect(res.body.areas[1].numOfProperties).to.be.eql(5);
               expect(res.body.areas[1].minimumPrice).to.be.eql(100000);
               expect(res.body.areas[1].maximumPrice).to.be.eql(500000);

--- a/test/controllers/contentProperty.controller.test.js
+++ b/test/controllers/contentProperty.controller.test.js
@@ -510,11 +510,11 @@ describe('Content Property Controller', () => {
 
     context('when areas are sent in different cases', () => {
       const areaNameInDifferentCases = ['Ikoyi', 'IKOYI', 'IKOyi', 'ikoyi'];
-      [...new Array(4)].map((_, index) =>
+      areaNameInDifferentCases.map((areaName) =>
         it('returns array of house types', (done) => {
           request()
             .get(
-              `/api/v1/content-property/search?area=${areaNameInDifferentCases[index]}&state=${area.state}&houseType=${houseType}`,
+              `/api/v1/content-property/search?area=${areaName}&state=${area.state}&houseType=${houseType}`,
             )
             .end((err, res) => {
               expect(res).to.have.status(200);

--- a/test/controllers/contentProperty.controller.test.js
+++ b/test/controllers/contentProperty.controller.test.js
@@ -492,7 +492,7 @@ describe('Content Property Controller', () => {
       it('returns evaluation of 3 properties', (done) => {
         request()
           .get(
-            `/api/v1/content-property/search?area=${area.area}&state=${area.state}&type=${houseType}`,
+            `/api/v1/content-property/search?area=${area.area}&state=${area.state}&houseType=${houseType}`,
           )
           .end((err, res) => {
             expect(res).to.have.status(200);
@@ -506,6 +506,29 @@ describe('Content Property Controller', () => {
             done();
           });
       });
+    });
+
+    context('when areas are sent in different cases', () => {
+      const areaNameInDifferentCases = ['Ikoyi', 'IKOYI', 'IKOyi', 'ikoyi'];
+      [...new Array(4)].map((_, index) =>
+        it('returns array of house types', (done) => {
+          request()
+            .get(
+              `/api/v1/content-property/search?area=${areaNameInDifferentCases[index]}&state=${area.state}&houseType=${houseType}`,
+            )
+            .end((err, res) => {
+              expect(res).to.have.status(200);
+              expect(res.body.success).to.be.eql(true);
+              expect(res.body.evaluation.minimumPrice).to.be.eql(1000000);
+              expect(res.body.evaluation.maximumPrice).to.be.eql(3000000);
+              expect(res.body.evaluation.averagePrice).to.be.eql(2000000);
+              expect(res.body.evaluation.type).to.be.eql(houseType);
+              expect(res.body.evaluation.areaName).to.be.eql(area.area);
+              expect(res.body.evaluation.stateName).to.be.eql(area.state);
+              done();
+            });
+        }),
+      );
     });
 
     context('when the area and state parameters are sent', () => {
@@ -583,7 +606,7 @@ describe('Content Property Controller', () => {
         sinon.stub(ContentProperty, 'aggregate').throws(new Error('Type Error'));
         request()
           .get(
-            `/api/v1/content-property/search?area=${area.area}&state=${area.state}&type=${houseType}`,
+            `/api/v1/content-property/search?area=${area.area}&state=${area.state}&houseType=${houseType}`,
           )
           .end((err, res) => {
             expect(res).to.have.status(500);

--- a/test/controllers/contentProperty.controller.test.js
+++ b/test/controllers/contentProperty.controller.test.js
@@ -20,7 +20,7 @@ const user = UserFactory.build({ role: USER_ROLE.USER, activated: true });
 const admin = UserFactory.build({ role: USER_ROLE.ADMIN, activated: true });
 const editor = UserFactory.build({ role: USER_ROLE.EDITOR, activated: true });
 const areaId = mongoose.Types.ObjectId();
-const area = AreaFactory.build({ _id: areaId });
+const area = AreaFactory.build({ _id: areaId, area: 'Ikoyi', state: 'Lagos' });
 
 describe('Content Property Controller', () => {
   beforeEach(async () => {
@@ -491,7 +491,9 @@ describe('Content Property Controller', () => {
     context('when parameters are sent', () => {
       it('returns evaluation of 3 properties', (done) => {
         request()
-          .get(`/api/v1/content-property?areaId=${areaId}&houseType=${houseType}`)
+          .get(
+            `/api/v1/content-property/search?area=${area.area}&state=${area.state}&type=${houseType}`,
+          )
           .end((err, res) => {
             expect(res).to.have.status(200);
             expect(res.body.success).to.be.eql(true);
@@ -506,10 +508,10 @@ describe('Content Property Controller', () => {
       });
     });
 
-    context('when the areaId parameter is given only', () => {
+    context('when the area and state parameters are sent', () => {
       it('returns evaluation of 8 properties', (done) => {
         request()
-          .get(`/api/v1/content-property?areaId=${areaId}`)
+          .get(`/api/v1/content-property/search?area=${area.area}&state=${area.state}`)
           .end((err, res) => {
             expect(res).to.have.status(200);
             expect(res.body.success).to.be.eql(true);
@@ -524,14 +526,40 @@ describe('Content Property Controller', () => {
       });
     });
 
+    context('when the area parameter is given only', () => {
+      it('returns not found', (done) => {
+        request()
+          .get(`/api/v1/content-property/search?area=${area.area}`)
+          .end((err, res) => {
+            expect(res).to.have.status(412);
+            expect(res.body.success).to.be.eql(false);
+            expect(res.body.message).to.be.eql('Invalid state or area');
+            done();
+          });
+      });
+    });
+
+    context('when the state parameter is given only', () => {
+      it('returns not found', (done) => {
+        request()
+          .get(`/api/v1/content-property/search?state=${area.state}`)
+          .end((err, res) => {
+            expect(res).to.have.status(412);
+            expect(res.body.success).to.be.eql(false);
+            expect(res.body.message).to.be.eql('Invalid state or area');
+            done();
+          });
+      });
+    });
+
     context('when the houseType parameter is given only', () => {
       it('returns not found', (done) => {
         request()
-          .get(`/api/v1/content-property?houseType=${houseType}`)
+          .get(`/api/v1/content-property/search?type=${houseType}`)
           .end((err, res) => {
-            expect(res).to.have.status(404);
+            expect(res).to.have.status(412);
             expect(res.body.success).to.be.eql(false);
-            expect(res.body.message).to.be.eql('Area not found');
+            expect(res.body.message).to.be.eql('Invalid state or area');
             done();
           });
       });
@@ -540,11 +568,11 @@ describe('Content Property Controller', () => {
     context('without parameters', () => {
       it('returns not found', (done) => {
         request()
-          .get('/api/v1/content-property')
+          .get('/api/v1/content-property/search')
           .end((err, res) => {
-            expect(res).to.have.status(404);
+            expect(res).to.have.status(412);
             expect(res.body.success).to.be.eql(false);
-            expect(res.body.message).to.be.eql('Area not found');
+            expect(res.body.message).to.be.eql('Invalid state or area');
             done();
           });
       });
@@ -554,7 +582,9 @@ describe('Content Property Controller', () => {
       it('returns the error', (done) => {
         sinon.stub(ContentProperty, 'aggregate').throws(new Error('Type Error'));
         request()
-          .get(`/api/v1/content-property?areaId=${areaId}&houseType=${houseType}`)
+          .get(
+            `/api/v1/content-property/search?area=${area.area}&state=${area.state}&type=${houseType}`,
+          )
           .end((err, res) => {
             expect(res).to.have.status(500);
             done();


### PR DESCRIPTION
#### What does this PR do?
Fix content property search to search by area and not areaId
Allowed search parameters to be case insensitive

#### Description of Task to be completed?
Fix content property search to search by area and not areaId
Allowed search parameters to be case insensitive

#### How should this be manually tested?
`GET /api/v1/content-property/search?area={area}&type={type}&state={state}`

#### What are the relevant pivotal tracker stories?
#175868402 #175868469