### PR TITLE
#176533740 allow sensitive data update unverify user

### DIFF
--- a/server/services/user.service.js
+++ b/server/services/user.service.js
@@ -533,7 +533,7 @@ const getStepsReadyForReview = (updatedVendor, user) => {
   return stepToReview;
 };
 
-const containsSensitiveInfo = (updatedVendor) => {
+const containsSensitiveInfo = (user) => {
   const sensitive = [
     'bankInfo',
     'companyLogo',
@@ -544,9 +544,9 @@ const containsSensitiveInfo = (updatedVendor) => {
     'taxCertificate',
   ];
 
-  const isSensitive = sensitive.some((key) => Object.keys(updatedVendor).includes(key));
+  const updatedVendorInfo = Object.keys({ ...user, ...user.vendor });
 
-  return !isSensitive;
+  return sensitive.some((info) => updatedVendorInfo.includes(info));
 };
 
 export const updateVendor = async ({ updatedVendor, user }) => {
@@ -571,9 +571,7 @@ export const updateVendor = async ({ updatedVendor, user }) => {
   const vendor = {
     ...user.vendor,
     ...updatedVendor.vendor,
-    verified: updatedVendor.vendor
-      ? containsSensitiveInfo(updatedVendor.vendor)
-      : user.vendor.verified,
+    verified: containsSensitiveInfo(updatedVendor) ? false : user.vendor.verified,
   };
 
   vendor.verification = { ...vendor.verification, ...stepToReview.verification };

--- a/server/services/user.service.js
+++ b/server/services/user.service.js
@@ -533,6 +533,22 @@ const getStepsReadyForReview = (updatedVendor, user) => {
   return stepToReview;
 };
 
+const containsSensitiveInfo = (updatedVendor) => {
+  const sensitive = [
+    'bankInfo',
+    'companyLogo',
+    'companyName',
+    'entity',
+    'identification',
+    'redanNumber',
+    'taxCertificate',
+  ];
+
+  const isSensitive = sensitive.some((key) => Object.keys(updatedVendor).includes(key));
+
+  return !isSensitive;
+};
+
 export const updateVendor = async ({ updatedVendor, user }) => {
   const stepToReview = getStepsReadyForReview(updatedVendor, user);
 
@@ -552,7 +568,13 @@ export const updateVendor = async ({ updatedVendor, user }) => {
     Array.prototype.push.apply(updatedVendor.vendor.socialMedia, user.vendor.socialMedia);
   }
 
-  const vendor = { ...user.vendor, ...updatedVendor.vendor };
+  const vendor = {
+    ...user.vendor,
+    ...updatedVendor.vendor,
+    verified: updatedVendor.vendor
+      ? containsSensitiveInfo(updatedVendor.vendor)
+      : user.vendor.verified,
+  };
 
   vendor.verification = { ...vendor.verification, ...stepToReview.verification };
 

--- a/test/controllers/user.controller.test.js
+++ b/test/controllers/user.controller.test.js
@@ -1793,6 +1793,7 @@ describe('User Controller', () => {
               expect(res.body.user._id).to.be.eql(vendorId.toString());
               expect(res.body.user.phone).to.be.eql(data.phone);
               expect(res.body.user.phone2).to.be.eql(data.phone2);
+              expect(res.body.user.vendor.verified).to.be.eql(false);
               expect(res.body.user.address).to.be.eql({
                 ...vendorUser.address,
                 ...data.address,
@@ -1810,6 +1811,55 @@ describe('User Controller', () => {
                 'In Review',
               );
               expect(res.body.user.vendor.verification.directorInfo.status).to.be.eql('In Review');
+              done();
+            });
+        });
+      });
+
+      context('when non sensitive data is sent', () => {
+        const nonSensitiveData = {
+          phone: '12345678901',
+          phone2: '12345678901',
+          address: {
+            country: 'Ghana',
+            state: 'Accra',
+          },
+          vendor: {
+            directors: [
+              {
+                name: 'John Doe',
+                isSignatory: false,
+                phone: '08012345678',
+              },
+            ],
+            socialMedia: [
+              {
+                name: 'Facebook',
+                url: 'https://facebook.com/highrachy',
+              },
+            ],
+            website: 'https://highrachy.com/',
+          },
+        };
+        it('verification status remains same', (done) => {
+          request()
+            [method](endpoint)
+            .set('authorization', vendorToken)
+            .send(nonSensitiveData)
+            .end((err, res) => {
+              expect(res).to.have.status(200);
+              expect(res.body.success).to.be.eql(true);
+              expect(res.body.message).to.be.eql('Vendor information updated');
+              expect(res.body.user._id).to.be.eql(vendorId.toString());
+              expect(res.body.user.phone).to.be.eql(nonSensitiveData.phone);
+              expect(res.body.user.phone2).to.be.eql(nonSensitiveData.phone2);
+              expect(res.body.user.address).to.be.eql({
+                ...vendorUser.address,
+                ...nonSensitiveData.address,
+              });
+              expect(res.body.user.vendor.socialMedia.length).to.be.eql(2);
+              expect(res.body.user.vendor.directors.length).to.be.eql(2);
+              expect(res.body.user.vendor.verified).to.be.eql(true);
               done();
             });
         });

--- a/test/controllers/user.controller.test.js
+++ b/test/controllers/user.controller.test.js
@@ -1740,7 +1740,7 @@ describe('User Controller', () => {
       const endpoint = '/api/v1/user/vendor/update';
       const method = 'put';
 
-      const data = {
+      const sensitiveData = {
         phone: '12345678901',
         phone2: '12345678901',
         address: {
@@ -1803,145 +1803,119 @@ describe('User Controller', () => {
         },
       };
 
+      const itReturnsUpdatedVendor = (res, data) => {
+        expect(res).to.have.status(200);
+        expect(res.body.success).to.be.eql(true);
+        expect(res.body.message).to.be.eql('Vendor information updated');
+        expect(res.body.user._id).to.be.eql(vendorUser._id.toString());
+        expect(res.body.user.phone).to.be.eql(data.phone);
+        expect(res.body.user.phone2).to.be.eql(data.phone2);
+        expect(res.body.user.address).to.be.eql({
+          ...vendorUser.address,
+          ...data.address,
+        });
+        expect(res.body.user.vendor.companyName).to.be.eql(vendorUser.vendor.companyName);
+        expect(res.body.user.vendor.companyLogo).to.be.eql(data.vendor.companyLogo);
+        expect(res.body.user.vendor.bankInfo).to.be.eql(data.vendor.bankInfo);
+        expect(res.body.user.vendor.entity).to.be.eql(data.vendor.entity);
+        expect(res.body.user.vendor.taxCertificate).to.be.eql(data.vendor.taxCertificate);
+        expect(res.body.user.vendor.socialMedia.length).to.be.eql(2);
+        expect(res.body.user.vendor.directors.length).to.be.eql(2);
+        expect(res.body.user.vendor.verification.companyInfo.status).to.be.eql('In Review');
+        expect(res.body.user.vendor.verification.directorInfo.status).to.be.eql('In Review');
+      };
+
       beforeEach(async () => {
         vendorToken = await addUser(vendorUser);
       });
 
-      context('when vendor is verified and sensitive data is sent', () => {
-        it('returns updated vendor', (done) => {
-          request()
-            [method](endpoint)
-            .set('authorization', vendorToken)
-            .send(data)
-            .end((err, res) => {
-              expect(res).to.have.status(200);
-              expect(res.body.success).to.be.eql(true);
-              expect(res.body.message).to.be.eql('Vendor information updated');
-              expect(res.body.user._id).to.be.eql(vendorUser._id.toString());
-              expect(res.body.user.phone).to.be.eql(data.phone);
-              expect(res.body.user.phone2).to.be.eql(data.phone2);
-              expect(res.body.user.vendor.verified).to.be.eql(false);
-              expect(res.body.user.address).to.be.eql({
-                ...vendorUser.address,
-                ...data.address,
-              });
-              expect(res.body.user.vendor.companyName).to.be.eql(vendorUser.vendor.companyName);
-              expect(res.body.user.vendor.companyLogo).to.be.eql(data.vendor.companyLogo);
-              expect(res.body.user.vendor.bankInfo).to.be.eql(data.vendor.bankInfo);
-              expect(res.body.user.vendor.entity).to.be.eql(data.vendor.entity);
-              expect(res.body.user.vendor.taxCertificate).to.be.eql(data.vendor.taxCertificate);
-              expect(res.body.user.vendor.socialMedia.length).to.be.eql(2);
-              expect(res.body.user.vendor.directors.length).to.be.eql(2);
-              expect(res.body.user.vendor.verification.companyInfo.status).to.be.eql('In Review');
-              expect(res.body.user.vendor.verification.bankDetails.status).to.be.eql('In Review');
-              expect(res.body.user.vendor.verification.documentUpload.status).to.be.eql(
-                'In Review',
-              );
-              expect(res.body.user.vendor.verification.directorInfo.status).to.be.eql('In Review');
-              done();
-            });
-        });
-      });
-
-      context('when vendor is verified and non sensitive data is sent', () => {
-        it('verification status remains true', (done) => {
-          request()
-            [method](endpoint)
-            .set('authorization', vendorToken)
-            .send(nonSensitiveData)
-            .end((err, res) => {
-              expect(res).to.have.status(200);
-              expect(res.body.success).to.be.eql(true);
-              expect(res.body.message).to.be.eql('Vendor information updated');
-              expect(res.body.user._id).to.be.eql(vendorUser._id.toString());
-              expect(res.body.user.phone).to.be.eql(nonSensitiveData.phone);
-              expect(res.body.user.phone2).to.be.eql(nonSensitiveData.phone2);
-              expect(res.body.user.address).to.be.eql({
-                ...vendorUser.address,
-                ...nonSensitiveData.address,
-              });
-              expect(res.body.user.vendor.socialMedia.length).to.be.eql(2);
-              expect(res.body.user.vendor.directors.length).to.be.eql(2);
-              expect(res.body.user.vendor.verified).to.be.eql(true);
-              done();
-            });
-        });
-      });
-
-      context('when vendor is unverified and sensitive data is sent', () => {
-        beforeEach(async () => {
-          await User.findByIdAndUpdate(vendorUser._id, { 'vendor.verified': false });
-        });
-        it('returns updated vendor', (done) => {
-          request()
-            [method](endpoint)
-            .set('authorization', vendorToken)
-            .send(data)
-            .end((err, res) => {
-              expect(res).to.have.status(200);
-              expect(res.body.success).to.be.eql(true);
-              expect(res.body.message).to.be.eql('Vendor information updated');
-              expect(res.body.user._id).to.be.eql(vendorUser._id.toString());
-              expect(res.body.user.phone).to.be.eql(data.phone);
-              expect(res.body.user.phone2).to.be.eql(data.phone2);
-              expect(res.body.user.vendor.verified).to.be.eql(false);
-              expect(res.body.user.address).to.be.eql({
-                ...vendorUser.address,
-                ...data.address,
-              });
-              expect(res.body.user.vendor.companyName).to.be.eql(vendorUser.vendor.companyName);
-              expect(res.body.user.vendor.companyLogo).to.be.eql(data.vendor.companyLogo);
-              expect(res.body.user.vendor.bankInfo).to.be.eql(data.vendor.bankInfo);
-              expect(res.body.user.vendor.entity).to.be.eql(data.vendor.entity);
-              expect(res.body.user.vendor.taxCertificate).to.be.eql(data.vendor.taxCertificate);
-              expect(res.body.user.vendor.socialMedia.length).to.be.eql(2);
-              expect(res.body.user.vendor.directors.length).to.be.eql(2);
-              expect(res.body.user.vendor.verification.companyInfo.status).to.be.eql('In Review');
-              expect(res.body.user.vendor.verification.bankDetails.status).to.be.eql('In Review');
-              expect(res.body.user.vendor.verification.documentUpload.status).to.be.eql(
-                'In Review',
-              );
-              expect(res.body.user.vendor.verification.directorInfo.status).to.be.eql('In Review');
-              done();
-            });
-        });
-      });
-
-      context('when vendor is unverified and non sensitive data is sent', () => {
-        beforeEach(async () => {
-          await User.findByIdAndUpdate(vendorUser._id, { 'vendor.verified': false });
-        });
-        it('verification status remains false', (done) => {
-          request()
-            [method](endpoint)
-            .set('authorization', vendorToken)
-            .send(nonSensitiveData)
-            .end((err, res) => {
-              expect(res).to.have.status(200);
-              expect(res.body.success).to.be.eql(true);
-              expect(res.body.message).to.be.eql('Vendor information updated');
-              expect(res.body.user._id).to.be.eql(vendorUser._id.toString());
-              expect(res.body.user.phone).to.be.eql(nonSensitiveData.phone);
-              expect(res.body.user.phone2).to.be.eql(nonSensitiveData.phone2);
-              expect(res.body.user.address).to.be.eql({
-                ...vendorUser.address,
-                ...nonSensitiveData.address,
-              });
-              expect(res.body.user.vendor.socialMedia.length).to.be.eql(2);
-              expect(res.body.user.vendor.directors.length).to.be.eql(2);
-              expect(res.body.user.vendor.verified).to.be.eql(false);
-              done();
-            });
-        });
-      });
-
-      context('updating a single field', () => {
-        Object.keys(data).map((field) =>
+      context('when vendor is verified', () => {
+        context('when sensitive data is sent', () => {
           it('returns updated vendor', (done) => {
             request()
               [method](endpoint)
               .set('authorization', vendorToken)
-              .send({ [field]: data[field] })
+              .send(sensitiveData)
+              .end((err, res) => {
+                itReturnsUpdatedVendor(res, sensitiveData);
+                expect(res.body.user.vendor.verification.bankDetails.status).to.be.eql('In Review');
+                expect(res.body.user.vendor.verification.documentUpload.status).to.be.eql(
+                  'In Review',
+                );
+                expect(res.body.user.vendor.verified).to.be.eql(false);
+                done();
+              });
+          });
+        });
+
+        context('when non sensitive data is sent', () => {
+          it('verification status remains true', (done) => {
+            request()
+              [method](endpoint)
+              .set('authorization', vendorToken)
+              .send(nonSensitiveData)
+              .end((err, res) => {
+                itReturnsUpdatedVendor(res, nonSensitiveData);
+                expect(res.body.user.vendor.verification.bankDetails.status).to.be.eql('Pending');
+                expect(res.body.user.vendor.verification.documentUpload.status).to.be.eql(
+                  'Pending',
+                );
+                expect(res.body.user.vendor.verified).to.be.eql(true);
+                done();
+              });
+          });
+        });
+      });
+
+      context('when vendor is unverified', () => {
+        beforeEach(async () => {
+          await User.findByIdAndUpdate(vendorUser._id, { 'vendor.verified': false });
+        });
+
+        context('when sensitive data is sent', () => {
+          it('returns updated vendor', (done) => {
+            request()
+              [method](endpoint)
+              .set('authorization', vendorToken)
+              .send(sensitiveData)
+              .end((err, res) => {
+                itReturnsUpdatedVendor(res, sensitiveData);
+                expect(res.body.user.vendor.verification.bankDetails.status).to.be.eql('In Review');
+                expect(res.body.user.vendor.verification.documentUpload.status).to.be.eql(
+                  'In Review',
+                );
+                expect(res.body.user.vendor.verified).to.be.eql(false);
+                done();
+              });
+          });
+        });
+
+        context('when non sensitive data is sent', () => {
+          it('verification status remains false', (done) => {
+            request()
+              [method](endpoint)
+              .set('authorization', vendorToken)
+              .send(nonSensitiveData)
+              .end((err, res) => {
+                itReturnsUpdatedVendor(res, nonSensitiveData);
+                expect(res.body.user.vendor.verification.bankDetails.status).to.be.eql('Pending');
+                expect(res.body.user.vendor.verification.documentUpload.status).to.be.eql(
+                  'Pending',
+                );
+                expect(res.body.user.vendor.verified).to.be.eql(false);
+                done();
+              });
+          });
+        });
+      });
+
+      context('updating a single field', () => {
+        Object.keys(sensitiveData).map((field) =>
+          it('returns updated vendor', (done) => {
+            request()
+              [method](endpoint)
+              .set('authorization', vendorToken)
+              .send({ [field]: sensitiveData[field] })
               .end((err, res) => {
                 expect(res).to.have.status(200);
                 expect(res.body.success).to.be.eql(true);
@@ -1957,14 +1931,14 @@ describe('User Controller', () => {
       itReturnsForbiddenForNoToken({
         endpoint,
         method,
-        data,
+        data: sensitiveData,
       });
 
       itReturnsForbiddenForTokenWithInvalidAccess({
         endpoint,
         method,
         user: invalidUser,
-        data,
+        data: sensitiveData,
       });
 
       itReturnsNotFoundForInvalidToken({
@@ -1972,7 +1946,7 @@ describe('User Controller', () => {
         method,
         user: invalidUser,
         userId: invalidUserId,
-        data,
+        data: sensitiveData,
       });
 
       context('when findByIdAndUpdate returns an error', () => {
@@ -1981,7 +1955,7 @@ describe('User Controller', () => {
           request()
             [method](endpoint)
             .set('authorization', vendorToken)
-            .send(data)
+            .send(sensitiveData)
             .end((err, res) => {
               expect(res).to.have.status(400);
               expect(res.body.success).to.be.eql(false);


### PR DESCRIPTION
#### What does this PR do?
Change vendor to unverified when sensitive information is updated.

#### Description of Task to be completed?
Change vendor to unverified when sensitive information is updated.
#### How should this be manually tested?
`PUT /api/v1/user/vendor/update`

#### What are the relevant pivotal tracker stories?
#176533740