### PR TITLE
#176735760 load additional information when user is viewing a single property

### DIFF
--- a/server/controllers/property.controllers.js
+++ b/server/controllers/property.controllers.js
@@ -63,7 +63,8 @@ const PropertyController = {
 
   getOneProperty(req, res, next) {
     const propertId = req.params.id;
-    getOneProperty(propertId)
+    const { user } = req;
+    getOneProperty(propertId, user)
       .then((property) => {
         if (property.length > 0) {
           res.status(httpStatus.OK).json({ success: true, property: property[0] });

--- a/server/services/property.service.js
+++ b/server/services/property.service.js
@@ -162,7 +162,7 @@ export const getOneProperty = async (propertyId, user = {}) => {
     },
   ];
 
-  if (user && user.role === USER_ROLE.USER) {
+  if (user?.role === USER_ROLE.USER) {
     propertyOptions.splice(
       1,
       0,
@@ -181,7 +181,6 @@ export const getOneProperty = async (propertyId, user = {}) => {
                 },
               },
             },
-            { $project: { propertyId: 0, _id: 0 } },
           ],
           as: 'enquiryInfo',
         },
@@ -201,15 +200,16 @@ export const getOneProperty = async (propertyId, user = {}) => {
                 },
               },
             },
-            { $project: { propertyId: 0, _id: 0 } },
           ],
           as: 'visitationInfo',
         },
       },
     );
     propertyOptions.splice(propertyOptions.length - 1, 0, {
-      $unwind: '$enquiryInfo',
-      preserveNullAndEmptyArrays: true,
+      $unwind: {
+        path: '$enquiryInfo',
+        preserveNullAndEmptyArrays: true,
+      },
     });
     propertyOptions[propertyOptions.length - 1].$project = {
       ...propertyOptions[propertyOptions.length - 1].$project,


### PR DESCRIPTION
#### What does this PR do?
Return visitation and enquiry when viewing a single property for a user

#### Description of Task to be completed?
Return visitation and enquiry when viewing a single property for a user

#### How should this be manually tested?
`GET /api/v1/property/:id`

#### What are the relevant pivotal tracker stories?
#176735760