### PR TITLE
#176843020  implement filter functionality for `GET /api/v1/offer/all` endpoint

### DIFF
--- a/server/controllers/offer.controllers.js
+++ b/server/controllers/offer.controllers.js
@@ -96,8 +96,8 @@ const OfferController = {
 
   getAllOffers(req, res, next) {
     const userId = req.user._id;
-    const { page, limit } = req.query;
-    getAllOffers(userId, page, limit)
+    const { query } = req;
+    getAllOffers(userId, query)
       .then(({ pagination, result }) => {
         res.status(httpStatus.OK).json({
           success: true,

--- a/server/helpers/filters.js
+++ b/server/helpers/filters.js
@@ -99,3 +99,22 @@ export const PROPERTY_FILTERS = {
   toilets: { type: FILTER_TYPE.INTEGER },
   units: { type: FILTER_TYPE.INTEGER },
 };
+
+export const OFFER_FILTERS = {
+  allocationInPercentage: { type: FILTER_TYPE.INTEGER },
+  contributionReward: { type: FILTER_TYPE.INTEGER },
+  createdAt: { type: FILTER_TYPE.DATE },
+  deliveryState: { type: FILTER_TYPE.STRING },
+  expires: { type: FILTER_TYPE.DATE },
+  handOverDate: { type: FILTER_TYPE.DATE },
+  initialPayment: { type: FILTER_TYPE.INTEGER },
+  monthlyPayment: { type: FILTER_TYPE.INTEGER },
+  paymentFrequency: { type: FILTER_TYPE.INTEGER },
+  propertyId: { type: FILTER_TYPE.OBJECT_ID },
+  referenceCode: { type: FILTER_TYPE.STRING },
+  status: { type: FILTER_TYPE.STRING },
+  title: { type: FILTER_TYPE.STRING },
+  totalAmountPayable: { type: FILTER_TYPE.INTEGER },
+  userId: { type: FILTER_TYPE.OBJECT_ID },
+  vendorId: { type: FILTER_TYPE.OBJECT_ID },
+};


### PR DESCRIPTION
#### What does this PR do?
Implement filter functionality for `GET offer/all` endpoint

#### Description of Task to be completed?
-Paginate `GET /api/v1/offer/all`

#### How should this be manually tested?
`GET /api/v1/offer/all?filterKey=value`

```
DATE = yyyy-mm-dd
INTEGER = number
OBJECT_ID = valid mongo id
STRING = matching text (case insensitive)
```

Example `/api/v1/offer/all?expires=2021-01-26&totalAmountPayable=300000&contributionReward=0`

```
allocationInPercentage: INTEGER 
contributionReward: INTEGER 
createdAt: DATE 
deliveryState: STRING 
expires: DATE 
handOverDate: DATE 
initialPayment: INTEGER 
monthlyPayment: INTEGER 
paymentFrequency: INTEGER 
propertyId: OBJECT_ID 
referenceCode: STRING 
status: STRING 
title: STRING 
totalAmountPayable: INTEGER 
userId: OBJECT_ID 
vendorId: OBJECT_ID 
```

#### What are the relevant pivotal tracker stories?
#176843020