### PR TITLE
#177638840  fix property gallery so new images are added to top

### DIFF
--- a/server/services/property.service.js
+++ b/server/services/property.service.js
@@ -594,11 +594,12 @@ export const addGallery = async (imageDetails) => {
   if (gallery.length > 0) {
     throw new ErrorHandler(httpStatus.PRECONDITION_FAILED, 'Image with title already exists');
   }
+  const newGallery = [{ title: imageDetails.title, url: imageDetails.url }, ...property.gallery];
 
   try {
     return Property.findByIdAndUpdate(
       property._id,
-      { $push: { gallery: { title: imageDetails.title, url: imageDetails.url } } },
+      { $set: { gallery: newGallery } },
       { new: true },
     );
   } catch (error) {

--- a/test/controllers/property.controller.test.js
+++ b/test/controllers/property.controller.test.js
@@ -3531,10 +3531,10 @@ describe('Property Controller', () => {
             expect(res.body.success).to.be.eql(true);
             expect(res.body.message).to.be.eql('Image added');
             expect(res.body.property.gallery.length).to.be.eql(2);
-            expect(res.body.property.gallery[0].title).to.be.eql(property.gallery[0].title);
-            expect(res.body.property.gallery[0].url).to.be.eql(property.gallery[0].url);
-            expect(res.body.property.gallery[1].title).to.be.eql(data.title);
-            expect(res.body.property.gallery[1].url).to.be.eql(data.url);
+            expect(res.body.property.gallery[0].title).to.be.eql(data.title);
+            expect(res.body.property.gallery[0].url).to.be.eql(data.url);
+            expect(res.body.property.gallery[1].title).to.be.eql(property.gallery[0].title);
+            expect(res.body.property.gallery[1].url).to.be.eql(property.gallery[0].url);
             done();
           });
       });


### PR DESCRIPTION
#### What does this PR do?
Add new image in property gallery to top of gallery array

#### Description of Task to be completed?
Add new image in property gallery to top of gallery array


#### How should this be manually tested?
`POST /api/v1/property/:id/gallery`

#### What are the relevant pivotal tracker stories?
#177638840
