### PR TITLE
#178769329 fix returned info bug for badges

### DIFF
--- a/server/helpers/projectedSchemaInfo.js
+++ b/server/helpers/projectedSchemaInfo.js
@@ -115,6 +115,8 @@ export const PROJECTED_BADGE_INFO = {
   name: 1,
   image: 1,
   updatedAt: 1,
+  icon: 1,
+  slug: 1,
 };
 
 export const PROJECTED_REFERRAL_INFO = {

--- a/server/services/user.service.js
+++ b/server/services/user.service.js
@@ -687,6 +687,14 @@ export const getOneUser = async (userId) =>
       },
     },
     {
+      $lookup: {
+        from: 'badges',
+        localField: 'assignedBadges.badgeId',
+        foreignField: '_id',
+        as: 'badges',
+      },
+    },
+    {
       $project: {
         password: 0,
         notifications: 0,

--- a/test/controllers/badge.controller.test.js
+++ b/test/controllers/badge.controller.test.js
@@ -549,6 +549,7 @@ describe('Badge Controller', () => {
                 expect(res.body.result[0].name).to.be.eql(badge.name);
                 expect(res.body.result[0].addedBy).to.be.eql(badge.addedBy.toString());
                 expect(res.body.result[0].assignedRole).to.be.eql(badge.assignedRole);
+                expect(res.body.result[0].icon).to.be.eql(badge.icon);
                 expect(res.body.result[0].noOfAssignedUsers).to.be.eql(2);
                 expect(res.body.result[1]._id).to.be.eql(badges[0]._id.toString());
                 expect(res.body.result[1].name).to.be.eql(badges[0].name);

--- a/test/controllers/badge.controller.test.js
+++ b/test/controllers/badge.controller.test.js
@@ -480,7 +480,7 @@ describe('Badge Controller', () => {
         assignedRole: BADGE_ACCESS_LEVEL.VENDOR,
         createdAt: futureDate,
         name: 'Special vendor badge',
-        slug: 'special_vendor_badge',
+        slug: 'special-vendor-badge',
       },
       { generateId: true },
     );

--- a/test/controllers/user.controller.test.js
+++ b/test/controllers/user.controller.test.js
@@ -2843,6 +2843,8 @@ describe('User Controller', () => {
                 assignedAllBadge._id.toString(),
               );
               expect(res.body.user.assignedBadges[1]._id).to.be.eql(assignUserBadge._id.toString());
+              expect(res.body.user.badges[0]._id).to.be.eql(userBadge._id.toString());
+              expect(res.body.user.badges[1]._id).to.be.eql(allBadge._id.toString());
               done();
             });
         });

--- a/test/controllers/user.controller.test.js
+++ b/test/controllers/user.controller.test.js
@@ -55,6 +55,7 @@ import BadgeFactory from '../factories/badge.factory';
 import AssignedBadgeFactory from '../factories/assignedBadge.factory';
 import { addBadge } from '../../server/services/badge.service';
 import { assignBadge } from '../../server/services/assignedBadge.service';
+import { slugify } from '../../server/helpers/funtions';
 
 let adminToken;
 let userToken;
@@ -2780,7 +2781,7 @@ describe('User Controller', () => {
       const endpoint = `/api/v1/user/${testUser._id}`;
 
       const userBadge = BadgeFactory.build(
-        { assignedRole: BADGE_ACCESS_LEVEL.USER },
+        { assignedRole: BADGE_ACCESS_LEVEL.USER, name: 'Special badge' },
         { generateId: true },
       );
 
@@ -2844,6 +2845,10 @@ describe('User Controller', () => {
               );
               expect(res.body.user.assignedBadges[1]._id).to.be.eql(assignUserBadge._id.toString());
               expect(res.body.user.badges[0]._id).to.be.eql(userBadge._id.toString());
+              expect(res.body.user.badges[0].name).to.be.eql(userBadge.name);
+              expect(res.body.user.badges[0].image).to.be.eql(userBadge.image);
+              expect(res.body.user.badges[0].icon).to.be.eql(userBadge.icon);
+              expect(res.body.user.badges[0].slug).to.be.eql(slugify(userBadge.name));
               expect(res.body.user.badges[1]._id).to.be.eql(allBadge._id.toString());
               done();
             });


### PR DESCRIPTION
#### What does this PR do?
Fix returned info bug for badges

#### Description of Task to be completed?
- Badges info is missing for a single user (badges name and other necessary info are not returned)
- Icons not returned for, getAll badges endpoint

#### How should this be manually tested?
NA

#### What are the relevant pivotal tracker stories?
#178769329